### PR TITLE
Getting list id

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can then edit that file and include any defaults you want to set. I would hi
 	:apikey: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-usx
 	:list: xxxxxxxxxx
 
-> Note: once you get your api key you can get the list id by running 'mc list lists'.
+> Note: once you get your api key you can get the list id by running 'mc lists list'.
 
 ## Todo
 * Finish supporting all api calls


### PR DESCRIPTION
Running 'mc list lists' -> 'mc lists list' (arguments should be swapped). 

The error is:

```
$HOME.gem/ruby/2.5.0/gems/mc-0.0.8/lib/mc/commands/campaigns.rb:117: warning: key :inline_css is duplicated and overwritten on line 123
Command 'lists' requires a subcommand group,grouping,merge-vars,webhook,abuse-reports,clients,growth,list,locations,member-activity,member-info,members,subscribe,static-segments,segments
```